### PR TITLE
Fix File reference check

### DIFF
--- a/components/file-upload/file-uploader.class.ts
+++ b/components/file-upload/file-uploader.class.ts
@@ -3,7 +3,7 @@ import { FileItem } from './file-item.class';
 import { FileType } from './file-type.class';
 
 function isFile(value:any):boolean {
-  return (File && value instanceof File);
+  return typeof File !== 'undefined' && value instanceof File;
 }
 // function isFileLikeObject(value:any) {
 export interface Headers {


### PR DESCRIPTION
## Summary
- avoid ReferenceError in `isFile` helper when `File` is not defined

## Testing
- `npm test` *(fails: `./node_modules/.bin/eslint: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68404ef16358832099244326e454d9b9