### PR TITLE
Add custom filter support for FileSelectDirective

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Follow me [![twitter](https://img.shields.io/twitter/follow/valorkin.svg?style=s
 ### Properties
 
   - `uploader` - (`FileUploader`) - uploader object. See using in [demo](https://github.com/valor-software/ng2-file-upload/blob/master/demo/components/file-upload/simple-demo.ts)
+  - `ng2FileSelectFilters` - (`any`) - custom filters passed to uploader when adding files
 
 ## API for `ng2FileDrop`
 

--- a/components/file-upload/file-drop.directive.spec.ts
+++ b/components/file-upload/file-drop.directive.spec.ts
@@ -6,10 +6,11 @@ import { FileUploadModule } from './file-upload.module';
 
 @Component({
   selector: 'container',
-  template: `<input type="file" ng2FileSelect [uploader]="uploader" />`
+  template: `<input type="file" ng2FileSelect [uploader]="uploader" [ng2FileSelectFilters]="filters" />`
 })
 export class ContainerComponent {
   public uploader:FileUploader = new FileUploader({url: 'localhost:3000'});
+  public filters:any;
 }
 
 describe('Directive: FileSelectDirective', () => {
@@ -25,4 +26,16 @@ describe('Directive: FileSelectDirective', () => {
   it('should be fine', inject([ContainerComponent], (fixture:ComponentFixture<ContainerComponent>) => {
     expect(fixture).not.toBeNull();
   }));
+
+  it('should apply custom filters', () => {
+    const fixture = TestBed.createComponent(ContainerComponent);
+    const comp = fixture.componentInstance;
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    comp.filters = [{ name: 'acceptNone', fn: () => false }];
+    fixture.detectChanges();
+    const input = fixture.debugElement.nativeElement.querySelector('input');
+    Object.defineProperty(input, 'files', { value: [file] });
+    input.dispatchEvent(new Event('change'));
+    expect(comp.uploader.queue.length).toBe(0);
+  });
 });

--- a/components/file-upload/file-select.directive.ts
+++ b/components/file-upload/file-select.directive.ts
@@ -2,11 +2,10 @@ import { Directive, ElementRef, Input, HostListener } from '@angular/core';
 
 import { FileUploader } from './file-uploader.class';
 
-// todo: filters
-
 @Directive({selector: '[ng2FileSelect]'})
 export class FileSelectDirective {
   @Input() public uploader:FileUploader;
+  @Input() public ng2FileSelectFilters:any;
 
   private element:ElementRef;
 
@@ -19,7 +18,7 @@ export class FileSelectDirective {
   }
 
   public getFilters():any {
-    return void 0;
+    return this.ng2FileSelectFilters;
   }
 
   public isEmptyAfterSelection():boolean {

--- a/components/file-upload/readme.md
+++ b/components/file-upload/readme.md
@@ -19,6 +19,7 @@ import { FileSelectDirective, FileDropDirective, FileUploader } from 'ng2-file-u
 ### Properties
 
   - `uploader` - (`FileUploader`) - uploader object. See using in [demo](https://github.com/valor-software/ng2-file-upload/blob/master/demo/components/file-upload/simple-demo.ts)
+  - `ng2FileSelectFilters` - (`any`) - custom filters passed to uploader when adding files
 
   Parameters supported by this object:
 


### PR DESCRIPTION
## Summary
- expose `ng2FileSelectFilters` input on FileSelectDirective
- document new input in both READMEs
- verify custom filter behavior via unit test

## Testing
- `npm test` *(fails: `./node_modules/.bin/eslint: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68404fdceb5c8320b475f87527817009